### PR TITLE
[Feat] 인지훈련 사용자 점수 매기기

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,10 @@
 from fastapi import FastAPI
-from app.chat import app as chat_app
+from app.score.router import router as score_router
 from app.internal.router import router as internal_router
+from app.chat import app as chat_app
 
 app = FastAPI()
 
 app.mount("/chat", chat_app)
 app.include_router(internal_router, prefix="/internal")
+app.include_router(score_router)

--- a/app/score/router.py
+++ b/app/score/router.py
@@ -1,0 +1,92 @@
+from fastapi import APIRouter
+from openai import OpenAI
+from dotenv import load_dotenv
+import os
+from pydantic import BaseModel
+import json
+
+load_dotenv()
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+router = APIRouter()
+
+system_prompt = """
+You are an evaluation assistant for a cognitive training service designed for elderly users.
+
+Your task is to evaluate how well a user-written summary captures the overall context and main idea of a news article.
+This evaluation must be gentle, generous, and supportive.
+
+Core principles:
+- Do NOT evaluate like an exam or test.
+- Do NOT apply strict or harsh standards.
+- If the overall meaning and context are preserved, give a high score even if the wording is imperfect.
+- Focus on meaning and understanding, not on grammar, sentence structure, or vocabulary.
+- Be generous with scores so that users do not feel discouraged.
+- NEVER assign a score below 60.
+- Do NOT provide any feedback or explanation in words.
+- 정확한 워딩이 달라도 맥락이 맞으면 높은 점수를 주세요. 
+- 얼마나 맞았는가를 보기보다는, 틀리지 않으면 감점하지 않는 방향으로 최대한 높은 점수를 주세요. 
+
+Evaluation criteria (internal use only):
+- Whether the user understood the main topic and overall context of the article
+- Whether the core event or narrative flow is preserved
+- Whether the meaning is not significantly distorted
+
+Output rules:
+- Respond ONLY in valid JSON format.
+- Do NOT include any text outside the JSON.
+
+Required output format:
+{
+  "score": integer (range: 60 to 100)
+}
+
+Score guideline:
+- Main context and key idea clearly preserved: 85–100 (but I recommend around 88)
+- Some key points included, overall flow maintained: 75–84
+- Simple or vague, but meaning still conveyed: 60–74
+- 웬만큼 못한 게 아니면 80점 이상은 주세요 
+"""
+
+
+class SummaryScoreRequest(BaseModel):
+    article: str
+    correct_summary: str
+    user_summary: str
+
+
+class SummaryScoreResponse(BaseModel):
+    score: int
+
+
+@router.post("/score", response_model=SummaryScoreResponse)
+def evaluate_summary(request: SummaryScoreRequest):
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",
+        temperature=0.3,
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {
+                "role": "user",
+                "content": f"""
+[기사 원문]
+{request.article}
+
+[모범 요약]
+{request.correct_summary}
+
+[사용자 요약]
+{request.user_summary}
+"""
+            }
+        ]
+    )
+
+    try:
+        parsed = json.loads(response.choices[0].message.content.strip())
+        score = int(parsed.get("score", 60))
+    except Exception:
+        score = 60
+
+    score = max(60, min(100, score))
+    return SummaryScoreResponse(score=score)


### PR DESCRIPTION
## 📌 관련 이슈
closed #9 

## ✨ 작업 내용
인지훈련 사용자들의 훈련 결과 점수를 매기고 db에 저장합니다. 
프론트에는 summary의 모범답안을 보여줍니다.

## 📸 스크린샷
<img width="1746" height="1024" alt="image" src="https://github.com/user-attachments/assets/6ef0707d-b8e9-4b44-9c82-0c7f67f955ee" />

위의 예시 정도로 맥락이 너무 틀린 게 아니면 최소 60점은 주도록 했고, 보통 잘 맞게 말하면 85점 정도 나오는 것 같습니다. 

## 📚 참고 사항
